### PR TITLE
Fix the Euclidean operator to work with negative steps

### DIFF
--- a/teletype/euclidean/euclidean.c
+++ b/teletype/euclidean/euclidean.c
@@ -56,7 +56,10 @@ int euclidean(int fill, int len, int step) {
 	int entry_size = len / 8;
 	if (len % 8 > 0) entry_size++;
 	const char* table = &len_table[fill * entry_size];
-	return get_bit(table, step % len);
+	// adjust step, s.t. 0 <= step < len
+	int remainder = step % len;
+	int modulo = remainder < 0 ? remainder + len : remainder;
+	return get_bit(table, modulo);
  }
 
 


### PR DESCRIPTION
The `ER` operator wasn't working correctly with a negative step value. Negative steps can come about in normal use when you're trying to do an offset, e.g.

```
ER fill length SUB step rotation
```

Anyway, turns out `%` in C is a remainder, rather than modulo, e.g:

```c
#include <stdio.h>

int main() {
	for (int step=-10; step<=10; step++) {
		int length = 4;
		int remainder = step % length;
		int modulo = remainder < 0 ? remainder + length : remainder;
		printf("step: %3i   remainder: %2i   modulo: %i\n", step, remainder, modulo);
	}
}
```
gives:
```text
step: -10   remainder: -2   modulo: 2
step:  -9   remainder: -1   modulo: 3
step:  -8   remainder:  0   modulo: 0
step:  -7   remainder: -3   modulo: 1
step:  -6   remainder: -2   modulo: 2
step:  -5   remainder: -1   modulo: 3
step:  -4   remainder:  0   modulo: 0
step:  -3   remainder: -3   modulo: 1
step:  -2   remainder: -2   modulo: 2
step:  -1   remainder: -1   modulo: 3
step:   0   remainder:  0   modulo: 0
step:   1   remainder:  1   modulo: 1
step:   2   remainder:  2   modulo: 2
step:   3   remainder:  3   modulo: 3
step:   4   remainder:  0   modulo: 0
step:   5   remainder:  1   modulo: 1
step:   6   remainder:  2   modulo: 2
step:   7   remainder:  3   modulo: 3
step:   8   remainder:  0   modulo: 0
step:   9   remainder:  1   modulo: 1
step:  10   remainder:  2   modulo: 2
```